### PR TITLE
Inherit typographic styles on form elements

### DIFF
--- a/typography.css
+++ b/typography.css
@@ -17,4 +17,14 @@
       monospace, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
       'Noto Color Emoji';
   }
+
+  :where(input, textarea, select, button) {
+    background-color: transparent;
+    color: inherit;
+    font: inherit;
+    letter-spacing: inherit;
+    word-spacing: inherit;
+    text-transform: inherit;
+    text-shadow: inherit;
+  }
 }


### PR DESCRIPTION
Lets `input`, `textarea`, `select`, and `button` inherit type styles